### PR TITLE
Update Client to latest version (v58)

### DIFF
--- a/Crypto/PepperCrypto.js
+++ b/Crypto/PepperCrypto.js
@@ -4,7 +4,7 @@ crypto = require("crypto");
 
 module.exports = class {
     constructor() {
-        this.server_public_key = fromHexString("8434902B6A7D834C222FBEE06BE5950194B70D1B9F2DF140B4A36460900E032E");
+        this.server_public_key = fromHexString("F7C80C59E42D4165A32D5D440A6939D54D18BB7F1B2335E85650673C27AA974F");
         this.client_secret_key = new Uint8Array(crypto.randomBytes(32));
         this.client_public_key = new Uint8Array(32);
         Nacl.lowlevel.crypto_scalarmult_base(this.client_public_key, this.client_secret_key);

--- a/Messaging/Messages/Client/ClientHelloMessage.js
+++ b/Messaging/Messages/Client/ClientHelloMessage.js
@@ -6,7 +6,7 @@ module.exports = class {
     }
     encode() {
         this.ByteStream.writeInt(2); // protocol version
-        this.ByteStream.writeInt(35); // crypto version
+        this.ByteStream.writeInt(47); // crypto version
         this.ByteStream.writeInt(settings.major); // major version
         this.ByteStream.writeInt(settings.build); // build version
         this.ByteStream.writeInt(settings.minor); // minor version

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BrawlStars-Client
-client for brawl stars v47 prod server
+client for brawl stars v58 prod server
 
 # NOTE
 This content is not affiliated with, endorsed,sponsored, or specifically approved by supercell and supercell is not responsible for it.
@@ -27,6 +27,7 @@ program will gonna use default values 🙃
 
 # credits
 this project was made by [S.B#0056](https://github.com/HaccerCat) and [risporce#6552](https://github.com/risporce)
+v58 update by [@kubune](https://github.com/kubune)
 
 ## give a 🌟 because why not :p
 

--- a/settings.json
+++ b/settings.json
@@ -1,6 +1,6 @@
 {
-    "hash": "6ebd39e6a3941f9f793fcda37eecc82a21749691",
-    "major": 47,
-    "minor": 246,
+    "hash": "fed02985594937339ad92e5ce5d65e3be64ea4bc",
+    "major": 58,
+    "minor": 295,
     "build": 1
 }


### PR DESCRIPTION
This pull request updates the client to work with latest Brawl Stars version
I tested the client and it works.
The key was leaked by rldv in this version and people would update the client by themselfs anyway.
I won't be making new pull requests until a new public leak happens.
